### PR TITLE
New MathOps feature: if it's not + or * then we have an error

### DIFF
--- a/src/main/scala/MathsOps.scala
+++ b/src/main/scala/MathsOps.scala
@@ -1,3 +1,4 @@
 object MathOps:
     def addTwoNumbers(a: Int, b: Int) = a + b
     def multiplyTwoNumbers(a: Int, b: Int)= a*b
+

--- a/src/test/scala/MathsOpsSpec.scala
+++ b/src/test/scala/MathsOpsSpec.scala
@@ -12,5 +12,14 @@ class MathOpsSpec extends AnyFlatSpec with must.Matchers {
   "Multiplying 7 and 9" must "give 63" in{
     MathOps.multiplyTwoNumbers(7, 9) mustEqual 63
   }
+  "the * character" must "result to an addition of 2 numbers" in {
+    val operation = MathOpsInput.parse("*")
+    operation(5, 11) mustEqual 55
+  }
+  "any character other than + or *" must "result in an error" in {
+    assertThrows[RuntimeException] {
+        MathOpsInput.parse("o")
+    }
+  }
 }
 


### PR DESCRIPTION
introducing exceptions  